### PR TITLE
Update: ignore leading spaces

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -14,7 +14,7 @@ type Input struct {
 }
 
 func (i *Input) getCmdName() string {
-	elms := strings.Split(i.BufferLeft, " ")
+	elms := strings.Split(strings.TrimSpace(i.BufferLeft), " ")
 	if len(elms) == 0 {
 		return ""
 	}

--- a/test/pmy_testcases.json
+++ b/test/pmy_testcases.json
@@ -1,5 +1,15 @@
 [
   {
+    "lbuffer": "cd ",
+    "rbuffer": "",
+    "expected": "cd test_directory/"
+  },
+  {
+    "lbuffer": " cd ",
+    "rbuffer": "",
+    "expected": " cd test_directory/"
+  },
+  {
     "lbuffer": "git checkout mas",
     "rbuffer": "",
     "expected": "git checkout master"

--- a/test/rules/cd_pmy_rules.json
+++ b/test/rules/cd_pmy_rules.json
@@ -1,6 +1,6 @@
 [
   {
-    "regexpLeft": "^cd +(?P<path>([^/]*/)*)(?P<query>[^/]*)$",
+    "regexpLeft": "(?P<space>\\s*)cd +(?P<path>([^/]*/)*)(?P<query>[^/]*)$",
     "cmdGroups": [
       {
         "tag": "",
@@ -9,7 +9,7 @@
       }
     ],
     "fuzzyFinderCmd": "fzf -0 -1 -q \"<query>\"",
-    "bufferLeft": "cd <path>",
+    "bufferLeft": "<space>cd <path>",
     "bufferRight": "[]"
   }
 ]


### PR DESCRIPTION
In command specific rules, allow a space at the beginning of the command.

I use this feature with `hist_ignore_space` option.
