### PR TITLE
feat(config,log): add `PMY_LOG_PATH` env var to customize the log output path

### DIFF
--- a/src/aop.go
+++ b/src/aop.go
@@ -10,12 +10,11 @@ import (
 // MeasureElapsedTime measures elapsed time given
 // a started time.
 func MeasureElapsedTime(start time.Time, name string) {
-	logPath := os.ExpandEnv(defaultLogPath)
-	err := os.MkdirAll(path.Dir(logPath), os.ModePerm)
+	err := os.MkdirAll(path.Dir(LogPath), os.ModePerm)
 	if err != nil {
 		return
 	}
-	f, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	f, err := os.OpenFile(LogPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
 		log.Fatalf("error opening file: %v", err)
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -10,6 +10,7 @@ const (
 	defaultLogPath      string = "${HOME}/.pmy/log.txt"
 	rulesPathVarName    string = "PMY_RULE_PATH"
 	snippetPathVarName  string = "PMY_SNIPPET_PATH"
+	logPathVarName      string = "PMY_LOG_PATH"
 	tagDelimiterVarName string = "PMY_TAG_DELIMITER"
 )
 
@@ -18,6 +19,8 @@ var (
 	RulePath string
 	// SnippetPath defines snippet root directry path
 	SnippetPath string
+	// LogPath is a path of the log file
+	LogPath string
 	// TagDelimiter defines delimiter string
 	// that divide `tag` and one line of source
 	TagDelimiter = "\\t"
@@ -27,9 +30,11 @@ var (
 func setConfig(
 	target *string,
 	varName string,
+	defaultValue string,
 ) {
 	envVar, ok := os.LookupEnv(varName)
 	if !ok {
+		*target = defaultValue
 		return
 	}
 	*target = envVar
@@ -38,7 +43,8 @@ func setConfig(
 // SetConfigs set all Pmy config variable from shell's
 // environment variables.
 func SetConfigs() {
-	setConfig(&RulePath, rulesPathVarName)
-	setConfig(&SnippetPath, snippetPathVarName)
-	setConfig(&TagDelimiter, tagDelimiterVarName)
+	setConfig(&RulePath, rulesPathVarName, "")
+	setConfig(&SnippetPath, snippetPathVarName, "")
+	setConfig(&LogPath, logPathVarName, os.ExpandEnv(defaultLogPath))
+	setConfig(&TagDelimiter, tagDelimiterVarName, "")
 }


### PR DESCRIPTION
e.g.)
```sh
$ export PMY_LOG_PATH="$XDG_CACHE_HOME/pmy/log.txt"
$ pmy --version
pmy version 0.5.5
$ ls $XDG_CACHE_HOME/pmy
log.txt
```
